### PR TITLE
Minor revisions to black hole accretion rate model

### DIFF
--- a/diffaux/black_hole_modeling/black_hole_accretion_rate.py
+++ b/diffaux/black_hole_modeling/black_hole_accretion_rate.py
@@ -1,7 +1,6 @@
 """ """
 
 import numpy as np
-from halotools.utils import monte_carlo_from_cdf_lookup
 
 A = 10**-3.15
 gamma_e = -0.65
@@ -92,9 +91,12 @@ def monte_carlo_eddington_ratio(redshift, sfr_percentile):
     assert len(redshift) == 1, msg
 
     rate_table, prob_table = eddington_ratio_distribution(redshift[0])
-    return monte_carlo_from_cdf_lookup(
-        rate_table, prob_table, mc_input=1 - sfr_percentile
-    )
+    mc_input = 1 - sfr_percentile
+    return monte_carlo_from_cdf_lookup(rate_table, prob_table, mc_input)
+
+
+def monte_carlo_from_cdf_lookup(x_table, y_table, mc_input):
+    return np.interp(np.atleast_1d(mc_input), x_table, y_table)
 
 
 def monte_carlo_bh_acc_rate(redshift, black_hole_mass, sfr_percentile):
@@ -131,9 +133,9 @@ def monte_carlo_bh_acc_rate(redshift, black_hole_mass, sfr_percentile):
     >>> ngals = int(1e4)
     >>> sfr_percentile = np.random.uniform(0, 1, ngals)
     >>> black_hole_mass = 10**np.random.uniform(6, 11, ngals)
-    >>> edd_ratio, acc_rate = monte_carlo_bh_acc_rate(redshift,
-                                                      black_hole_mass,
-                                                      sfr_percentile)
+    >>> args = redshift, black_hole_mass, sfr_percentile
+    >>> edd_ratio, acc_rate = monte_carlo_bh_acc_rate(*args)
+
     """
     redshift = np.atleast_1d(redshift)
     msg = (

--- a/diffaux/black_hole_modeling/black_hole_accretion_rate.py
+++ b/diffaux/black_hole_modeling/black_hole_accretion_rate.py
@@ -48,6 +48,7 @@ def eddington_ratio_distribution(redshift, npts=1000):
     )
     assert len(z) == 1, msg
     redshift = float(max(z[0], 0.0))
+    redshift = min(redshift, 5.0)  # No redshift evolution beyond z>5
     rate_table = np.logspace(-4, 0, npts)
     return (
         rate_table,

--- a/diffaux/black_hole_modeling/black_hole_accretion_rate.py
+++ b/diffaux/black_hole_modeling/black_hole_accretion_rate.py
@@ -1,8 +1,7 @@
-"""
-"""
+""" """
+
 import numpy as np
 from halotools.utils import monte_carlo_from_cdf_lookup
-
 
 A = 10**-3.15
 gamma_e = -0.65
@@ -10,11 +9,11 @@ gamma_z = 3.47
 z0 = 0.6
 
 
-__all__ = ('monte_carlo_bh_acc_rate', )
+__all__ = ("monte_carlo_bh_acc_rate",)
 
 
 def eddington_ratio_distribution(redshift, npts=1000):
-    """ Power law model for the PDF of the Eddington ratio.
+    """Power law model for the PDF of the Eddington ratio.
 
     Model is based on Aird, Coil, et al. (2011), arXiv:1107.4368.
 
@@ -44,12 +43,17 @@ def eddington_ratio_distribution(redshift, npts=1000):
     >>> rate_table, pdf_table = eddington_ratio_distribution(redshift)
     """
     z = np.atleast_1d(redshift)
-    msg = ("Input ``redshift`` argument to eddington_ratio_distribution function "
-           "must be a single float")
-    assert (len(z) == 1), msg
-    redshift = float(max(z[0], 0.))
+    msg = (
+        "Input ``redshift`` argument to eddington_ratio_distribution function "
+        "must be a single float"
+    )
+    assert len(z) == 1, msg
+    redshift = float(max(z[0], 0.0))
     rate_table = np.logspace(-4, 0, npts)
-    return rate_table, A*(((1. + redshift)/(1. + z0))**gamma_z)*rate_table**gamma_e
+    return (
+        rate_table,
+        A * (((1.0 + redshift) / (1.0 + z0)) ** gamma_z) * rate_table**gamma_e,
+    )
 
 
 def monte_carlo_eddington_ratio(redshift, sfr_percentile):
@@ -81,13 +85,16 @@ def monte_carlo_eddington_ratio(redshift, sfr_percentile):
 
     """
     redshift = np.atleast_1d(redshift)
-    msg = ("monte_carlo_eddington_ratio only accepts "
-           "a single float for ``redshift`` argument")
+    msg = (
+        "monte_carlo_eddington_ratio only accepts "
+        "a single float for ``redshift`` argument"
+    )
     assert len(redshift) == 1, msg
 
     rate_table, prob_table = eddington_ratio_distribution(redshift[0])
     return monte_carlo_from_cdf_lookup(
-        rate_table, prob_table, mc_input=1-sfr_percentile)
+        rate_table, prob_table, mc_input=1 - sfr_percentile
+    )
 
 
 def monte_carlo_bh_acc_rate(redshift, black_hole_mass, sfr_percentile):
@@ -129,11 +136,13 @@ def monte_carlo_bh_acc_rate(redshift, black_hole_mass, sfr_percentile):
                                                       sfr_percentile)
     """
     redshift = np.atleast_1d(redshift)
-    msg = ("monte_carlo_bh_acc_rate only accepts "
-           "a single float for ``redshift`` argument")
+    msg = (
+        "monte_carlo_bh_acc_rate only accepts "
+        "a single float for ``redshift`` argument"
+    )
     assert len(redshift) == 1, msg
 
     eddington_ratio = monte_carlo_eddington_ratio(redshift, sfr_percentile)
-    eddington_rate = black_hole_mass*2.2e-8
-    accretion_rate = eddington_ratio*eddington_rate
+    eddington_rate = black_hole_mass * 2.2e-8
+    accretion_rate = eddington_ratio * eddington_rate
     return eddington_ratio, accretion_rate

--- a/diffaux/black_hole_modeling/black_hole_mass.py
+++ b/diffaux/black_hole_modeling/black_hole_mass.py
@@ -1,10 +1,9 @@
-"""
-"""
-from astropy.utils.misc import NumpyRNGContext
+""" """
+
 import numpy as np
+from astropy.utils.misc import NumpyRNGContext
 
-
-__all__ = ('bh_mass_from_bulge_mass', 'monte_carlo_black_hole_mass')
+__all__ = ("bh_mass_from_bulge_mass", "monte_carlo_black_hole_mass")
 fixed_seed = 43
 
 
@@ -29,8 +28,8 @@ def bh_mass_from_bulge_mass(bulge_mass):
     >>> bulge_mass = np.logspace(8, 12, ngals)
     >>> bh_mass = bh_mass_from_bulge_mass(bulge_mass)
     """
-    prefactor = 0.49*(bulge_mass/100.)
-    return prefactor*(bulge_mass/1e11)**0.15
+    prefactor = 0.49 * (bulge_mass / 100.0)
+    return prefactor * (bulge_mass / 1e11) ** 0.15
 
 
 def monte_carlo_black_hole_mass(bulge_mass, seed=fixed_seed):
@@ -62,4 +61,4 @@ def monte_carlo_black_hole_mass(bulge_mass, seed=fixed_seed):
     """
     loc = np.log10(bh_mass_from_bulge_mass(bulge_mass))
     with NumpyRNGContext(seed):
-        return 10**np.random.normal(loc=loc, scale=0.28)
+        return 10 ** np.random.normal(loc=loc, scale=0.28)

--- a/diffaux/black_hole_modeling/tests/test_black_hole_accretion_rate.py
+++ b/diffaux/black_hole_modeling/tests/test_black_hole_accretion_rate.py
@@ -1,6 +1,7 @@
 """"""
 
 import numpy as np
+from jax import random as jran
 
 from .. import black_hole_accretion_rate as bhar
 
@@ -9,3 +10,25 @@ def test_eddington_ratio_distribution():
     redshift = 0.5
     rate_table, pdf_table = bhar.eddington_ratio_distribution(redshift)
     assert np.all(np.isfinite(pdf_table))
+
+
+def test_monte_carlo_eddington_ratio():
+    ran_key = jran.key(0)
+    npts = 5_000
+
+    for redshift in np.arange(0, 15):
+        ran_key, test_key = jran.split(ran_key, 2)
+        sfr_percentile = jran.uniform(
+            test_key, minval=1e-4, maxval=1 - 1e-4, shape=(npts,)
+        )
+
+        edd_ratio = bhar.monte_carlo_eddington_ratio(redshift, sfr_percentile)
+        assert np.all(np.isfinite(edd_ratio))
+
+        msk_q = sfr_percentile < 0.2
+        msk_sf = sfr_percentile > 0.8
+        mean_edd_ratio_q = edd_ratio[msk_q].mean()
+        mean_edd_ratio_sf = edd_ratio[msk_sf].mean()
+        assert mean_edd_ratio_q < mean_edd_ratio_sf
+
+        assert np.mean(edd_ratio > 1) < 0.1

--- a/diffaux/black_hole_modeling/tests/test_black_hole_accretion_rate.py
+++ b/diffaux/black_hole_modeling/tests/test_black_hole_accretion_rate.py
@@ -1,0 +1,11 @@
+""""""
+
+import numpy as np
+
+from .. import black_hole_accretion_rate as bhar
+
+
+def test_eddington_ratio_distribution():
+    redshift = 0.5
+    rate_table, pdf_table = bhar.eddington_ratio_distribution(redshift)
+    assert np.all(np.isfinite(pdf_table))


### PR DESCRIPTION
* Add unit tests of the model for black hole accretion rates (BH-MARs)
* Drop halotools dependency
* Shut down redshift evolution in the Eddington ratio distribution beyond z>5 (eliminates unphysical behavior in the PDF)

@evevkovacs I originally set out to JAXify this model. But I think it's fine as is for the time being, modulo these two things:
* The current implementation requires calculating the BH-MARs at a single redshift, and so when making lightcone mocks we can just use the snapshot redshift.
* This is formulated based on SFR percentile, which is a little unfortunate since this is not natively computed by Diffsky, and so we'll need to derive this from the mock through a rank-ordering exercise before calling the Eddington ratio code.